### PR TITLE
Update to trusty64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,7 @@ Vagrant.configure("2") do |config|
     settings_json_path = "settings.json"
     vagrant_settings = (JSON.parse(File.read(settings_json_path)))
 
-    config.vm.box = "precise32"
-    config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+    config.vm.box = "ubuntu/trusty64"
 
     #provisioning
     config.vm.provision "shell", path: "chuy/provision/preprovision.sh"

--- a/fabfile.py
+++ b/fabfile.py
@@ -320,30 +320,34 @@ def execute(command=""):
 
 @task
 def php_version():
-    select = True
-    while select:
-        print blue("Select version:")
-        option  = raw_input( blue("0) PHP 5.4\n1) PHP 5.5\n2) PHP 5.6\n>>") )
+    #  select = True
+    #  while select:
+        #  print blue("Select version:")
+        #  option  = raw_input( blue("0) PHP 5.4\n1) PHP 5.5\n2) PHP 5.6\n>>") )
 
-        if option == "0":
-            select = False
-            print "Installing php 5.4..."
-            state.output['stdout'] = True
-            run('sudo apt-get remove -y libapache2-mod-php5')
-            run('sudo add-apt-repository ppa:ondrej/php5-oldstable')
-        if option == "1":
-            select = False
-            print "Installing php 5.5..."
-            state.output['stdout'] = True
-            run('sudo apt-get remove -y libapache2-mod-php5')
-            run('sudo add-apt-repository ppa:ondrej/php5')
-        if option == "2":
-            select = False
-            print "Installing php 5.6..."
-            state.output['stdout'] = True
-            run('sudo apt-get remove -y libapache2-mod-php5')
-            run('sudo add-apt-repository ppa:ondrej/php5-5.6')
+        #  if option == "0":
+            #  select = False
+            #  print "Installing php 5.4..."
+            #  state.output['stdout'] = True
+            #  run('sudo apt-get remove -y libapache2-mod-php5')
+            #  run('sudo add-apt-repository ppa:ondrej/php5-oldstable')
+        #  if option == "1":
+            #  select = False
+            #  print "Installing php 5.5..."
+            #  state.output['stdout'] = True
+            #  run('sudo apt-get remove -y libapache2-mod-php5')
+            #  run('sudo add-apt-repository ppa:ondrej/php5')
+        #  if option == "2":
+            #  select = False
+            #  print "Installing php 5.6..."
+            #  state.output['stdout'] = True
+            #  run('sudo apt-get remove -y libapache2-mod-php5')
+            #  run('sudo add-apt-repository ppa:ondrej/php5-5.6')
+
+    print "Installing php 5.6..."
+    state.output['stdout'] = True
 
     run('sudo apt-get update')
-    run('sudo apt-get install php5')
-    run('sudo apt-get install libapache2-mod-php5')
+    #  run('sudo apt-get install php5')
+    #  run('sudo apt-get install libapache2-mod-php5')
+    run('sudo apt-get install libapache2-mod-php5.6 php5.6-apcu php-pear php5.6 php5.6-cgi php5.6-curl php5.6-fpm php5.6-gd php5.6-intl php5.6-mcrypt php5.6-memcached php5.6-mysql php5.6-mbstring php5.6-xml php5.6-zip unzip')

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -3,17 +3,23 @@
 apt-get update
 
 apt-get install python-software-properties --assume-yes
-add-apt-repository ppa:ondrej/php5-oldstable
+add-apt-repository ppa:ondrej/php
 
 apt-get update
 
 
 # Configurations
 
-PACKAGES="php5 mysql-client mysql-server php5-mysql apache2 tree vim curl git"
-PACKAGES="$PACKAGES nginx-full php5-fpm php5-cgi spawn-fcgi php-pear php5-gd libapache2-mod-php5"
-PACKAGES="$PACKAGES php-apc php5-curl php5-mcrypt php5-memcached fcgiwrap php5-mcrypt"
-PACKAGES="$PACKAGES php5-intl"
+PACKAGES="apache2 \
+  curl \
+  fcgiwrap \
+  git \
+  mysql-client \
+  mysql-server \
+  nginx-full \
+  spawn-fcgi \
+  tree \
+  vim"
 
 PUBLIC_DIRECTORY="/home/vagrant/public_www"
 DATABASE_DIRECTORY="/home/vagrant/database"
@@ -28,7 +34,7 @@ apt-get install $PACKAGES --assume-yes
 
 # Makes apache not init in start
 update-rc.d -f  apache2 remove
-update-rc.d php5-fpm defaults
+update-rc.d php5.6-fpm defaults
 
 # Public folder
 if [ ! -d "$PUBLIC_DIRECTORY" ]; then
@@ -63,12 +69,12 @@ service apache2 stop
 
 # Nginx
 cp /home/vagrant/templates/default.nginx /etc/nginx/sites-available/chuy
-cp /home/vagrant/templates/www.conf /etc/php5/fpm/pool.d/www.conf
+cp /home/vagrant/templates/www.conf /etc/php/5.6/fpm/pool.d/www.conf
 cp /home/vagrant/templates/nginx.conf /etc/nginx/nginx.conf
 cp /home/vagrant/templates/nginx.conf /home/vagrant/nginx.conf
 rm  /etc/nginx/sites-enabled/*
 ln -s /etc/nginx/sites-available/chuy /etc/nginx/sites-enabled/
-service php5-fpm restart
+service php5.6-fpm restart
 service nginx restart
 
 # Mysql create user chuy

--- a/provision/templates/cakephp.nginx
+++ b/provision/templates/cakephp.nginx
@@ -13,7 +13,7 @@ server {
 
     location ~ \.php$ {
         try_files $uri =404;
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php5.6-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;

--- a/provision/templates/default.nginx
+++ b/provision/templates/default.nginx
@@ -13,7 +13,7 @@ server {
 
     location ~ \.php$ {
         try_files $uri =404;
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php5.6-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;

--- a/provision/templates/drupal.nginx
+++ b/provision/templates/drupal.nginx
@@ -17,7 +17,7 @@ server {
 
     location ~ \.php$ {
         try_files $uri =404;
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php5.6-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;

--- a/provision/templates/laravel.nginx
+++ b/provision/templates/laravel.nginx
@@ -13,7 +13,7 @@ server {
 
     location ~ \.php$ {
         try_files $uri =404;
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php5.6-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;

--- a/provision/templates/prestashop.nginx
+++ b/provision/templates/prestashop.nginx
@@ -13,7 +13,7 @@ server {
 
     location ~ \.php$ {
         try_files $uri =404;
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php5.6-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;

--- a/provision/templates/symfony.nginx
+++ b/provision/templates/symfony.nginx
@@ -16,7 +16,7 @@ server {
     # This rule should only be placed on your development environment
     # In production, don't include this and don't deploy app_dev.php or config.php
     location ~ ^/(app_dev|config)\.php(/|$) {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php5.6-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         # When you are using symlinks to link the document root to the
@@ -31,7 +31,7 @@ server {
     }
     # PROD
     location ~ ^/app\.php(/|$) {
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass unix:/run/php/php5.6-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         # When you are using symlinks to link the document root to the

--- a/provision/templates/www.conf
+++ b/provision/templates/www.conf
@@ -5,7 +5,7 @@ listen.owner = www-data
 listen.group = www-data
 listen.mode = 0660
 
-listen = /var/run/php5-fpm.sock 
+listen = /run/php/php5.6-fpm.sock 
 
 pm = dynamic
 pm.max_children = 10


### PR DESCRIPTION
Updates the entire thing to use trusty64.

Also updates the provisioning scripts to install php-5.6 from
ppa:ondrej/php, and the configs for apache and nginx to use
the correct modules, sockets and dependencies.

Composer must be run now like this:

```
$ php5.6 /usr/local/bin/composer <params>
```

Based on this guide:
https://github.com/oerdnj/deb.sury.org/wiki/PPA-migration-to-ppa:ondrej-php
